### PR TITLE
Add theme toggler and basic i18n

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,9 +1,10 @@
 import { Link, useLocation } from 'react-router-dom';
 import { NavigationMenu, NavigationMenuItem, NavigationMenuList } from '@/components/ui/navigation-menu';
 import { Button } from '@/components/ui/button';
-import { BarChart3, Plus, List, Home, Settings, Menu, X } from 'lucide-react';
+import { BarChart3, Plus, List, Home, Settings, Menu, X, Sun, Moon } from 'lucide-react';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { useState } from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
 import { cn } from '@/lib/utils';
 
 export function Navbar() {
@@ -21,6 +22,7 @@ export function Navbar() {
     { path: '/expenses', icon: List, label: 'רשימת הוצאות' },
     { path: '/settings', icon: Settings, label: 'הגדרות' }
   ];
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <header className="sticky top-0 z-50 border-b bg-white/80 backdrop-blur-lg supports-[backdrop-filter]:bg-white/60">
@@ -69,6 +71,15 @@ export function Navbar() {
               ))}
             </NavigationMenuList>
           </NavigationMenu>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleTheme}
+            className="hidden md:inline-flex h-11 w-11 rounded-xl hover:bg-gray-100 transition-all"
+          >
+            {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+            <span className="sr-only">toggle theme</span>
+          </Button>
 
           {/* Mobile Menu - Enhanced */}
           <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
@@ -109,11 +120,11 @@ export function Navbar() {
 
               {/* Mobile Navigation */}
               <div className="flex flex-col gap-2 p-6">
-                {navItems.map(({ path, icon: Icon, label }) => (
-                  <Button
-                    key={path}
-                    variant={isActive(path) ? 'default' : 'ghost'}
-                    size="lg"
+              {navItems.map(({ path, icon: Icon, label }) => (
+                <Button
+                  key={path}
+                  variant={isActive(path) ? 'default' : 'ghost'}
+                  size="lg"
                     asChild
                     className={cn(
                       "justify-start h-14 rounded-xl font-medium transition-all duration-300",
@@ -137,6 +148,19 @@ export function Navbar() {
                     </Link>
                   </Button>
                 ))}
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  onClick={toggleTheme}
+                  className="justify-start h-14 rounded-xl"
+                >
+                  {theme === 'dark' ? (
+                    <Sun className="h-5 w-5 mr-4" />
+                  ) : (
+                    <Moon className="h-5 w-5 mr-4" />
+                  )}
+                  <span>{theme === 'dark' ? 'בהיר' : 'כהה'}</span>
+                </Button>
               </div>
 
               {/* Mobile Footer */}

--- a/src/components/layout/__tests__/Navbar.theme.test.tsx
+++ b/src/components/layout/__tests__/Navbar.theme.test.tsx
@@ -1,0 +1,19 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Navbar } from '../Navbar';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+import { BrowserRouter } from 'react-router-dom';
+
+it('toggles theme class on html element', () => {
+  const { getByRole } = render(
+    <ThemeProvider>
+      <BrowserRouter>
+        <Navbar />
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+  const button = getByRole('button', { name: /toggle theme/i });
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
+  fireEvent.click(button);
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+});

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext } from 'react';
+import { useSettings } from '@/hooks/useLocalStorage';
+
+const translations = {
+  he: {
+    'addExpense.title': 'הוסף הוצאה חדשה',
+    'addExpense.desc': 'רשום את ההוצאה החדשה שלך',
+    'addExpense.amount': 'סכום (₪)',
+    'addExpense.date': 'תאריך',
+    'addExpense.category': 'קטגוריה',
+    'addExpense.description': 'תיאור',
+    'addExpense.add': 'הוסף הוצאה',
+    'addExpense.adding': 'מוסיף...',
+    'addExpense.back': 'חזור לדשבורד',
+  },
+  en: {
+    'addExpense.title': 'Add New Expense',
+    'addExpense.desc': 'Record your new expense',
+    'addExpense.amount': 'Amount (₪)',
+    'addExpense.date': 'Date',
+    'addExpense.category': 'Category',
+    'addExpense.description': 'Description',
+    'addExpense.add': 'Add Expense',
+    'addExpense.adding': 'Adding...',
+    'addExpense.back': 'Back to Dashboard',
+  },
+};
+
+interface LanguageContextType {
+  lang: 'he' | 'en';
+  setLang: (l: 'he' | 'en') => void;
+  t: (key: string) => string;
+}
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [settings, setSettings] = useSettings();
+  const lang = settings.language as 'he' | 'en';
+  const setLang = (l: 'he' | 'en') => setSettings(prev => ({ ...prev, language: l }));
+  const t = (key: string) => translations[lang][key] || key;
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within LanguageProvider');
+  }
+  return context;
+}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useEffect } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useLocalStorage<Theme>('theme', 'light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from './contexts/ThemeContext'
+import { LanguageProvider } from './contexts/LanguageContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <LanguageProvider>
+        <App />
+      </LanguageProvider>
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/src/pages/AddExpense.tsx
+++ b/src/pages/AddExpense.tsx
@@ -12,6 +12,7 @@ import { Plus, ArrowRight, Calendar as CalendarIcon } from 'lucide-react';
 import { useAppData } from '@/hooks/useAppData';
 import type { Expense } from '@/types/expense';
 import { useToast } from '@/contexts/ToastContext';
+import { useLanguage } from '@/contexts/LanguageContext';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { cn } from '@/lib/utils';
 
@@ -24,6 +25,7 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
 
   const { allCategories } = useAppData();
   const { success, error } = useToast();
+  const { t } = useLanguage();
 
   const [amount, setAmount] = useState('');
   const [category, setCategory] = useState('');
@@ -140,8 +142,8 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">הוסף הוצאה חדשה</h1>
-        <p className="text-muted-foreground">רשום את ההוצאה החדשה שלך</p>
+        <h1 className="text-3xl font-bold tracking-tight">{t('addExpense.title')}</h1>
+        <p className="text-muted-foreground">{t('addExpense.desc')}</p>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-3">
@@ -162,7 +164,7 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
                 <div className="grid gap-4 md:grid-cols-2">
                   {/* Amount */}
                   <div className="space-y-2">
-                    <Label htmlFor="amount">סכום (₪)</Label>
+                    <Label htmlFor="amount">{t('addExpense.amount')}</Label>
                     <Input
                       id="amount"
                       type="number"
@@ -177,7 +179,7 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
 
                   {/* Date - במובייל input טבעי, בדסקטופ לוח שנה */}
                   <div className="space-y-2">
-                    <Label>תאריך</Label>
+                    <Label>{t('addExpense.date')}</Label>
                     {isMobile ? (
                       // Input טבעי למובייל
                       <Input
@@ -236,10 +238,10 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
 
                 {/* Category */}
                 <div className="space-y-2">
-                  <Label htmlFor="category">קטגוריה</Label>
+                  <Label htmlFor="category">{t('addExpense.category')}</Label>
                   <Select value={category} onValueChange={setCategory} required>
                     <SelectTrigger>
-                      <SelectValue placeholder="בחר קטגוריה" />
+                      <SelectValue placeholder={t('addExpense.category')} />
                     </SelectTrigger>
                     <SelectContent>
                       {allCategories.map((cat) => (
@@ -256,12 +258,12 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
 
                 {/* Description */}
                 <div className="space-y-2">
-                  <Label htmlFor="description">תיאור</Label>
+                  <Label htmlFor="description">{t('addExpense.description')}</Label>
                   <Textarea
                     id="description"
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
-                    placeholder="למשל: קפה בבית קפה, דלק לרכב..."
+                    placeholder={t('addExpense.description')}
                     rows={3}
                     required
                   />
@@ -277,12 +279,12 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
                     {isSubmitting ? (
                       <>
                         <LoadingSpinner size="sm" className="mr-2" />
-                        מוסיף...
+                        {t('addExpense.adding')}
                       </>
                     ) : (
                       <>
                         <Plus className="w-4 h-4 mr-2" />
-                        הוסף הוצאה
+                        {t('addExpense.add')}
                       </>
                     )}
                   </Button>
@@ -292,7 +294,7 @@ export function AddExpense({ onAddExpense }: AddExpenseProps) {
                     onClick={() => navigate('/')}
                   >
                     <ArrowRight className="w-4 h-4 mr-2" />
-                    חזור לדשבורד
+                    {t('addExpense.back')}
                   </Button>
                 </div>
               </form>

--- a/src/pages/__tests__/AddExpense.test.ts
+++ b/src/pages/__tests__/AddExpense.test.ts
@@ -3,4 +3,4 @@ describe('AddExpense', () => {
   it('should pass a simple test', () => {
     expect(true).toBe(true);
   });
-});``
+});

--- a/src/pages/__tests__/AddExpense.translation.test.tsx
+++ b/src/pages/__tests__/AddExpense.translation.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { AddExpense } from '../AddExpense';
+import { LanguageProvider } from '@/contexts/LanguageContext';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+
+it('renders english text when language is en', () => {
+  // Force english via initial settings
+  localStorage.setItem('settings', JSON.stringify({ monthlyBudget: 5000, currency: '₪', language: 'en' }));
+  render(
+    <ThemeProvider>
+      <LanguageProvider>
+        <BrowserRouter>
+          <AddExpense onAddExpense={jest.fn()} />
+        </BrowserRouter>
+      </LanguageProvider>
+    </ThemeProvider>
+  );
+  expect(screen.getByText('Add New Expense')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add ThemeContext for dark/light mode
- add LanguageContext with Hebrew/English strings
- use contexts in main entry
- add theme toggle button in Navbar
- translate AddExpense page via i18n
- add tests for theme toggle and translations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad4a814588331929531bde78a0f8e